### PR TITLE
DB-backed single key API

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -29,6 +29,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +65,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "async-trait"
@@ -433,14 +451,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
 
@@ -817,6 +837,18 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1344,6 +1376,19 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "heck"
@@ -1692,13 +1737,18 @@ dependencies = [
 name = "keystache"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "async-trait",
+ "chrono",
+ "libsqlite3-sys",
  "nip-70",
  "nostr-sdk",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tempfile",
  "tokio",
 ]
 
@@ -1736,6 +1786,17 @@ dependencies = [
  "bitflags 2.4.2",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2664,6 +2725,20 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.4.2",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3880,6 +3955,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version-compare"
 version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4552,4 +4633,24 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,9 +6,13 @@ authors = ["The Resolvr Team"]
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.80"
 async-trait = "0.1.77"
+chrono = { version = "0.4.34", features = ["alloc"] }
+libsqlite3-sys = { version = "0.28.0", features = ["bundled-sqlcipher"] }
 nip-70 = "0.5.0"
 nostr-sdk = "0.27.0"
+rusqlite = { version = "0.31.0", features = ["bundled-sqlcipher"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri = { version = "1.5", features = ["shell-open"] }
@@ -16,6 +20,9 @@ tokio = "1.36.0"
 
 [build-dependencies]
 tauri-build = { version = "1.5", features = [] }
+
+[dev-dependencies]
+tempfile = "3.10.0"
 
 [features]
 # This is used for production builds or when `devPath` points to the filesystem. DO NOT REMOVE!

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1,0 +1,668 @@
+use chrono::Utc;
+use nostr_sdk::prelude::*;
+use rusqlite::{params, Connection};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+const DATABASE_NAME: &str = "keystache.db";
+
+// TODO: Handle database migrations.
+
+/// Database handle for Keystache data.
+#[derive(Clone)]
+pub struct Database {
+    db_connection: Arc<Mutex<Connection>>,
+}
+
+impl Database {
+    /// Creates a new database handle in the Tauri app's data directory.
+    pub fn new_in_app_data_dir(app_handle: tauri::AppHandle) -> anyhow::Result<Self> {
+        let data_dir = match app_handle.path_resolver().app_data_dir() {
+            Some(x) => x,
+            None => return Err(anyhow::anyhow!("App data dir not found")),
+        };
+
+        Self::new(&data_dir, DATABASE_NAME, None)
+    }
+
+    fn new(
+        folder: &Path,
+        file_name: &str,
+        encryption_key_or: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        // The call to `Connection::open()` below doesn't
+        // create the directory if it doesn't exist, so we
+        // need to do it ourselves.
+        if !folder.try_exists()? {
+            std::fs::create_dir_all(folder)?;
+        }
+
+        let db_connection = Connection::open(folder.join(file_name))?;
+
+        if let Some(encryption_key) = encryption_key_or {
+            // Unlock the database with the encryption key.
+            db_connection.pragma_update(None, "key", encryption_key)?;
+        }
+
+        db_connection.execute(
+            "CREATE TABLE IF NOT EXISTS keys (
+                id INTEGER PRIMARY KEY,
+                nsec TEXT NOT NULL UNIQUE,
+                create_time TEXT NOT NULL
+            )",
+            [],
+        )?;
+
+        db_connection.execute(
+            "CREATE TABLE IF NOT EXISTS registered_applications (
+                id INTEGER PRIMARY KEY,
+                display_name TEXT,
+                application_npub TEXT NOT NULL UNIQUE,
+                create_time TEXT NOT NULL,
+                application_identity INTEGER NOT NULL,
+                FOREIGN KEY (application_identity) REFERENCES keys(id)
+            )",
+            [],
+        )?;
+
+        Ok(Database {
+            db_connection: Arc::from(Mutex::from(db_connection)),
+        })
+    }
+
+    /// Saves an nsec to the database.
+    pub fn save_nsec(&self, nsec: String) -> Result<(), rusqlite::Error> {
+        let db_connection = self.db_connection.lock().unwrap();
+
+        db_connection.execute(
+            "INSERT INTO keys (nsec, create_time) VALUES (?1, ?2)",
+            params![nsec, Utc::now().to_rfc3339()],
+        )?;
+        Ok(())
+    }
+
+    /// Removes an nsec from the database.
+    /// Returns an error if the nsec doesn't exist or if it is associated with any registered applications.
+    /// If the nsec is associated with any registered applications, the caller should unregister the applications first.
+    pub fn remove_nsec(&self, nsec: &str) -> Result<(), rusqlite::Error> {
+        let db_connection = self.db_connection.lock().unwrap();
+
+        db_connection.execute("DELETE FROM keys WHERE nsec = ?1", params![nsec])?;
+        Ok(())
+    }
+
+    /// Lists nsecs in the database. Ordered by id in ascending order.
+    /// Use limit and offset parameters for pagination.
+    pub fn list_nsecs(&self, limit: u64, offset: u64) -> Result<Vec<String>, rusqlite::Error> {
+        let db_connection = self.db_connection.lock().unwrap();
+
+        let mut stmt =
+            db_connection.prepare("SELECT nsec FROM keys ORDER BY id ASC LIMIT ?1 OFFSET ?2")?;
+
+        let nsec_iter = stmt.query_map(params![limit, offset], |row| row.get(0))?;
+
+        let mut nsecs = Vec::new();
+        for nsec in nsec_iter {
+            nsecs.push(nsec?);
+        }
+
+        Ok(nsecs)
+    }
+
+    /// Returns the first nsec in the database, or `None` if there are no nsecs.
+    pub fn get_first_nsec(&self) -> Result<Option<String>, rusqlite::Error> {
+        Ok(self.list_nsecs(1, 0)?.first().cloned())
+    }
+
+    /// Add a registered application to the database.
+    pub fn register_application(
+        &self,
+        display_name: Option<String>,
+        application_npub: String,
+        application_identity_nsec: String, // TODO: Make this take an npub instead of an nsec.
+    ) -> Result<(), rusqlite::Error> {
+        let db_connection = self.db_connection.lock().unwrap();
+
+        db_connection.execute(
+            "INSERT INTO registered_applications (display_name, application_npub, create_time, application_identity) VALUES (?1, ?2, ?3, (SELECT id FROM keys WHERE nsec = ?4))",
+            params![display_name, application_npub, Utc::now().to_rfc3339(), application_identity_nsec],
+        )?;
+        Ok(())
+    }
+
+    /// Removes a registered application from the database.
+    pub fn unregister_application(&self, application_npub: &str) -> Result<(), rusqlite::Error> {
+        let db_connection = self.db_connection.lock().unwrap();
+
+        db_connection.execute(
+            "DELETE FROM registered_applications WHERE application_npub = ?1",
+            params![application_npub],
+        )?;
+        Ok(())
+    }
+
+    /// Switch the Nostr key pair that a registered application is operating as.
+    pub fn swap_application_identity(
+        &self,
+        application_npub: &str,
+        new_application_identity_nsec: &str,
+    ) -> Result<(), rusqlite::Error> {
+        let db_connection = self.db_connection.lock().unwrap();
+
+        let updated_row_count = db_connection.execute(
+            "UPDATE registered_applications SET application_identity = (SELECT id FROM keys WHERE nsec = ?1) WHERE application_npub = ?2",
+            params![new_application_identity_nsec, application_npub],
+        )?;
+        if updated_row_count == 0 {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        }
+        Ok(())
+    }
+
+    /// Lists registered applications in the database. Ordered by id in ascending order.
+    /// Use limit and offset parameters for pagination.
+    pub fn list_registered_applications(
+        &self,
+        limit: u64,
+        offset: u64,
+    ) -> Result<Vec<(Option<String>, String, String)>, rusqlite::Error> {
+        let db_connection = self.db_connection.lock().unwrap();
+
+        let mut stmt = db_connection.prepare(
+            "SELECT display_name, application_npub, nsec FROM registered_applications
+            INNER JOIN keys ON registered_applications.application_identity = keys.id
+            ORDER BY registered_applications.id ASC LIMIT ?1 OFFSET ?2",
+        )?;
+
+        let application_iter = stmt.query_map(params![limit, offset], |row| {
+            Ok((
+                row.get::<_, Option<String>>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?;
+
+        let mut applications = Vec::new();
+        for application in application_iter {
+            applications.push(application?);
+        }
+
+        Ok(applications)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn get_temp_folder() -> PathBuf {
+        tempfile::TempDir::new()
+            .expect("Failed to create temporary directory")
+            .path()
+            .to_path_buf()
+    }
+
+    #[test]
+    fn open_db_where_folder_exists() {
+        let folder = get_temp_folder();
+        Database::new(&folder, "test.db", None).unwrap();
+    }
+
+    #[test]
+    fn open_db_where_folder_does_not_exist() {
+        let folder = get_temp_folder();
+        Database::new(&folder.join("non_existent_subfolder"), "test.db", None).unwrap();
+    }
+
+    #[test]
+    fn open_db_where_file_exists_at_folder_path() {
+        let folder = get_temp_folder();
+
+        std::fs::create_dir(&folder).unwrap();
+        std::fs::File::create(&folder.join("foo")).unwrap();
+
+        // Attempting to open a database where a file already exists at the folder path should cause an error.
+        let response = Database::new(&folder.join("foo"), "test.db", None);
+        assert!(response.is_err());
+    }
+
+    #[test]
+    fn open_db_where_folder_exists_at_file_path() {
+        let folder = get_temp_folder();
+
+        std::fs::create_dir(&folder).unwrap();
+        std::fs::create_dir(&folder.join("test.db")).unwrap();
+
+        // Attempting to open a database where a folder already exists at the file path should cause an error.
+        let response = Database::new(&folder, "test.db", None);
+        assert!(response.is_err());
+    }
+
+    #[test]
+    fn reopen_unencrypted_db() {
+        let folder = get_temp_folder();
+        let db = Database::new(&folder, "test.db", None).unwrap();
+        db.save_nsec("nsec".to_string()).unwrap();
+
+        drop(db);
+
+        let db = Database::new(&folder, "test.db", None).unwrap();
+        let response = db.get_first_nsec().unwrap().unwrap();
+        assert_eq!(response, "nsec");
+    }
+
+    #[test]
+    fn reopen_encrypted_db() {
+        let folder = get_temp_folder();
+        let db = Database::new(&folder, "test.db", Some("hello world")).unwrap();
+        db.save_nsec("nsec".to_string()).unwrap();
+
+        drop(db);
+
+        let db = Database::new(&folder, "test.db", Some("hello world")).unwrap();
+        let response = db.get_first_nsec().unwrap().unwrap();
+        assert_eq!(response, "nsec");
+    }
+
+    #[test]
+    fn reopen_encrypted_db_with_wrong_encryption_key_error() {
+        let folder = get_temp_folder();
+        let db = Database::new(&folder, "test.db", Some("hello world")).unwrap();
+
+        drop(db);
+
+        let db = Database::new(&folder, "test.db", Some("wrong key"));
+        assert!(db.is_err());
+    }
+
+    #[test]
+    fn reopen_encrypted_db_with_no_encryption_key_error() {
+        let folder = get_temp_folder();
+        let db = Database::new(&folder, "test.db", Some("hello world")).unwrap();
+
+        drop(db);
+
+        let db = Database::new(&folder, "test.db", None);
+        assert!(db.is_err());
+    }
+
+    #[test]
+    fn reopen_unencrypted_db_with_encryption_key_error() {
+        let folder = get_temp_folder();
+        let db = Database::new(&folder, "test.db", None).unwrap();
+
+        drop(db);
+
+        let db = Database::new(&folder, "test.db", Some("hello world"));
+        assert!(db.is_err());
+    }
+
+    #[test]
+    fn save_and_remove_nsec() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        // Save an nsec to the database.
+        db.save_nsec("nsec1".to_string()).unwrap();
+
+        // Check that the nsec was saved.
+        let response = db.list_nsecs(1, 0).unwrap();
+        assert_eq!(response, vec!["nsec1".to_string()]);
+
+        // Remove the nsec from the database.
+        db.remove_nsec("nsec1").unwrap();
+
+        // Check that the nsec was removed.
+        let response = db.list_nsecs(1, 0).unwrap();
+        assert!(response.is_empty());
+    }
+
+    #[test]
+    fn save_duplicate_nsec() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        // Save an nsec to the database.
+        db.save_nsec("nsec1".to_string()).unwrap();
+
+        // Saving the same nsec again should cause an error.
+        let response = db.save_nsec("nsec1".to_string());
+        assert!(response.is_err());
+    }
+
+    #[test]
+    fn remove_nsec_that_doesnt_exist() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        // Removing an nsec that doesn't exist should not cause an error.
+        let response = db.remove_nsec("nsec1");
+        assert!(response.is_ok());
+    }
+
+    #[test]
+    fn list_nsecs() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        // Returns an empty list since there are no nsecs in the database.
+        let response = db.list_nsecs(10, 0).unwrap();
+        assert!(response.is_empty());
+
+        // Using an offset with an empty database should return an empty list.
+        let response = db.list_nsecs(10, 1).unwrap();
+        assert!(response.is_empty());
+
+        // Add some nsecs to the database.
+        db.save_nsec("nsec1".to_string()).unwrap();
+        db.save_nsec("nsec2".to_string()).unwrap();
+        db.save_nsec("nsec3".to_string()).unwrap();
+
+        // Returns the nsecs in the database.
+        let response = db.list_nsecs(10, 0).unwrap();
+        assert_eq!(
+            response,
+            vec![
+                "nsec1".to_string(),
+                "nsec2".to_string(),
+                "nsec3".to_string()
+            ]
+        );
+
+        // Responds to limit.
+        let response = db.list_nsecs(2, 0).unwrap();
+        assert_eq!(response, vec!["nsec1".to_string(), "nsec2".to_string()]);
+
+        // Responds to limit and offset.
+        let response = db.list_nsecs(2, 2).unwrap();
+        assert_eq!(response, vec!["nsec3".to_string()]);
+
+        // Limit of 0 should return an empty list.
+        let response = db.list_nsecs(0, 0).unwrap();
+        assert!(response.is_empty());
+    }
+
+    #[test]
+    fn get_first_nsec() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        // Returns `None` since there are no nsecs in the database.
+        let response = db.get_first_nsec().unwrap();
+        assert_eq!(response, None);
+
+        // Add an nsec to the database.
+        db.save_nsec("nsec1".to_string()).unwrap();
+
+        // Returns the newly added nsec.
+        let response = db.get_first_nsec().unwrap();
+        assert_eq!(response, Some("nsec1".to_string()));
+
+        // Add more nsecs to the database.
+        db.save_nsec("nsec2".to_string()).unwrap();
+        db.save_nsec("nsec3".to_string()).unwrap();
+
+        // Still returns the first nsec.
+        let response = db.get_first_nsec().unwrap();
+        assert_eq!(response, Some("nsec1".to_string()));
+
+        // Remove the first nsec.
+        db.remove_nsec("nsec1").unwrap();
+
+        // Returns the next nsec.
+        let response = db.get_first_nsec().unwrap();
+        assert_eq!(response, Some("nsec2".to_string()));
+    }
+
+    #[test]
+    fn register_application_with_display_name_success() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        db.save_nsec("nsec".to_string()).unwrap();
+
+        db.register_application(
+            Some("display_name".to_string()),
+            "application_npub".to_string(),
+            "nsec".to_string(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn register_application_without_display_name_success() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        db.save_nsec("nsec".to_string()).unwrap();
+
+        db.register_application(None, "application_npub".to_string(), "nsec".to_string())
+            .unwrap();
+    }
+
+    #[test]
+    fn register_multiple_applications_with_same_identity_success() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        db.save_nsec("nsec".to_string()).unwrap();
+
+        db.register_application(
+            Some("display_name1".to_string()),
+            "application_npub1".to_string(),
+            "nsec".to_string(),
+        )
+        .unwrap();
+        db.register_application(
+            Some("display_name2".to_string()),
+            "application_npub2".to_string(),
+            "nsec".to_string(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn register_application_invalid_nsec_error() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        // Attempting to register an application with an nsec that doesn't exist should cause an error.
+        let response = db.register_application(
+            Some("display_name".to_string()),
+            "application_npub".to_string(),
+            "nsec".to_string(),
+        );
+        assert!(response.is_err());
+    }
+
+    #[test]
+    fn register_application_duplicate_application_npub_error() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        db.save_nsec("nsec1".to_string()).unwrap();
+
+        db.register_application(
+            Some("display_name".to_string()),
+            "application_npub".to_string(),
+            "nsec1".to_string(),
+        )
+        .unwrap();
+
+        // Attempting to register an application with the same application_npub should cause an error.
+        let response = db.register_application(
+            Some("display_name".to_string()),
+            "application_npub".to_string(),
+            "nsec2".to_string(),
+        );
+        assert!(response.is_err());
+    }
+
+    #[test]
+    fn unregister_application_success() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        db.save_nsec("nsec".to_string()).unwrap();
+
+        db.register_application(
+            Some("display_name".to_string()),
+            "application_npub".to_string(),
+            "nsec".to_string(),
+        )
+        .unwrap();
+
+        db.unregister_application("application_npub").unwrap();
+    }
+
+    #[test]
+    fn unregister_application_invalid_application_npub_error() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        // Attempting to unregister an application with an application_npub that doesn't exist should not cause an error.
+        let response = db.unregister_application("application_npub");
+        assert!(response.is_ok());
+    }
+
+    #[test]
+    fn swap_application_identity_success() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        db.save_nsec("nsec1".to_string()).unwrap();
+        db.save_nsec("nsec2".to_string()).unwrap();
+
+        db.register_application(
+            Some("display_name".to_string()),
+            "application_npub".to_string(),
+            "nsec1".to_string(),
+        )
+        .unwrap();
+
+        db.swap_application_identity("application_npub", "nsec2")
+            .unwrap();
+    }
+
+    #[test]
+    fn swap_application_identity_invalid_application_npub_error() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        db.save_nsec("nsec1".to_string()).unwrap();
+        db.save_nsec("nsec2".to_string()).unwrap();
+
+        // Attempting to swap the application identity of an application with an application_npub that doesn't exist should cause an error.
+        let response = db.swap_application_identity("application_npub", "nsec2");
+        assert!(response.is_err());
+    }
+
+    #[test]
+    fn swap_application_identity_invalid_new_identity_error() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        db.save_nsec("nsec1".to_string()).unwrap();
+        db.save_nsec("nsec2".to_string()).unwrap();
+
+        db.register_application(
+            Some("display_name".to_string()),
+            "application_npub".to_string(),
+            "nsec1".to_string(),
+        )
+        .unwrap();
+
+        // Attempting to swap the application identity of an application with an nsec that doesn't exist should cause an error.
+        let response = db.swap_application_identity("application_npub", "nsec3");
+        assert!(response.is_err());
+    }
+
+    #[test]
+    fn list_registered_applications() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        // Returns an empty list since there are no registered applications in the database.
+        let response = db.list_registered_applications(10, 0).unwrap();
+        assert!(response.is_empty());
+
+        // Using an offset with an empty database should return an empty list.
+        let response = db.list_registered_applications(10, 1).unwrap();
+        assert!(response.is_empty());
+
+        // Add some registered applications to the database.
+        db.save_nsec("nsec1".to_string()).unwrap();
+        db.save_nsec("nsec2".to_string()).unwrap();
+        db.save_nsec("nsec3".to_string()).unwrap();
+
+        db.register_application(
+            Some("display_name1".to_string()),
+            "application_npub1".to_string(),
+            "nsec1".to_string(),
+        )
+        .unwrap();
+        db.register_application(
+            Some("display_name2".to_string()),
+            "application_npub2".to_string(),
+            "nsec2".to_string(),
+        )
+        .unwrap();
+        // Register an application without a display name.
+        db.register_application(None, "application_npub3".to_string(), "nsec3".to_string())
+            .unwrap();
+
+        // Returns the registered applications in the database.
+        let response = db.list_registered_applications(10, 0).unwrap();
+        assert_eq!(
+            response,
+            vec![
+                (
+                    Some("display_name1".to_string()),
+                    "application_npub1".to_string(),
+                    "nsec1".to_string()
+                ),
+                (
+                    Some("display_name2".to_string()),
+                    "application_npub2".to_string(),
+                    "nsec2".to_string()
+                ),
+                (None, "application_npub3".to_string(), "nsec3".to_string())
+            ]
+        );
+
+        // Responds to limit.
+        let response = db.list_registered_applications(2, 0).unwrap();
+        assert_eq!(
+            response,
+            vec![
+                (
+                    Some("display_name1".to_string()),
+                    "application_npub1".to_string(),
+                    "nsec1".to_string()
+                ),
+                (
+                    Some("display_name2".to_string()),
+                    "application_npub2".to_string(),
+                    "nsec2".to_string()
+                )
+            ]
+        );
+
+        // Responds to limit and offset.
+        let response = db.list_registered_applications(2, 2).unwrap();
+        assert_eq!(
+            response,
+            vec![(None, "application_npub3".to_string(), "nsec3".to_string())]
+        );
+
+        // Limit of 0 should return an empty list.
+        let response = db.list_registered_applications(0, 0).unwrap();
+        assert!(response.is_empty());
+    }
+
+    #[test]
+    fn remove_nsec_used_by_registered_application_error() {
+        let db = Database::new(&get_temp_folder(), "test.db", None).unwrap();
+
+        db.save_nsec("nsec".to_string()).unwrap();
+
+        db.register_application(
+            Some("display_name".to_string()),
+            "application_npub".to_string(),
+            "nsec".to_string(),
+        )
+        .unwrap();
+
+        let response = db.remove_nsec("nsec");
+        assert!(response.is_err());
+
+        // Unregister the application first, then remove the nsec.
+        db.unregister_application("application_npub").unwrap();
+        db.remove_nsec("nsec").unwrap();
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,8 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod database;
+
 use async_trait::async_trait;
 use nip_70::{
     run_nip70_server, Nip70, Nip70ServerError, PayInvoiceRequest, PayInvoiceResponse, RelayPolicy,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,8 +10,8 @@ use nip_70::{
 };
 use nostr_sdk::event::{Event, UnsignedEvent};
 use nostr_sdk::key::{KeyPair, Secp256k1, SecretKey, XOnlyPublicKey};
-use nostr_sdk::Keys;
 use nostr_sdk::FromBech32;
+use nostr_sdk::Keys;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tauri::Manager;
@@ -54,10 +54,13 @@ impl KeystacheNip70 {
         // Wipe all existing keypairs.
         // TODO: Hardcoding the limit here isn't very robust. Should we allow for
         // setting it to `None` to allow for iterating through all keypairs?
-        for keypair in database.list_keypairs(10_000, 0).map_err(|_| Nip70ServerError::InternalError)? {
-            database.remove_keypair(&keypair.x_only_public_key().0).map_err(|_| {
-                Nip70ServerError::InternalError
-            })?;
+        for keypair in database
+            .list_keypairs(10_000, 0)
+            .map_err(|_| Nip70ServerError::InternalError)?
+        {
+            database
+                .remove_keypair(&keypair.x_only_public_key().0)
+                .map_err(|_| Nip70ServerError::InternalError)?;
         }
 
         // Save the new keypair.
@@ -205,8 +208,12 @@ async fn set_nsec(
     nsec: String,
     state: tauri::State<'_, Arc<KeystacheNip70>>,
 ) -> anyhow::Result<(), String> {
-    let keypair = SecretKey::from_bech32(nsec).map_err(|_| "Error parsing nsec")?.keypair(&Secp256k1::new());
-    state.set_keypair(keypair).map_err(|_| "Error setting keypair")?;
+    let keypair = SecretKey::from_bech32(nsec)
+        .map_err(|_| "Error parsing nsec")?
+        .keypair(&Secp256k1::new());
+    state
+        .set_keypair(keypair)
+        .map_err(|_| "Error setting keypair")?;
     Ok(())
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,20 +4,22 @@
 mod database;
 
 use async_trait::async_trait;
+use database::Database;
 use nip_70::{
     run_nip70_server, Nip70, Nip70ServerError, PayInvoiceRequest, PayInvoiceResponse, RelayPolicy,
 };
 use nostr_sdk::event::{Event, UnsignedEvent};
-use nostr_sdk::key::XOnlyPublicKey;
+use nostr_sdk::key::{KeyPair, Secp256k1, SecretKey, XOnlyPublicKey};
 use nostr_sdk::Keys;
+use nostr_sdk::FromBech32;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tauri::Manager;
 use tokio::sync::Mutex;
 
 struct KeystacheNip70 {
-    /// The key pair used to sign events.
-    keys: Keys,
+    /// Database handle. `None` if there was an error opening the database, otherwise `Some`.
+    database_or: Option<Database>,
 
     /// Map of hex-encoded event IDs to channels for signaling when the signing of an event has been approved/rejected.
     in_progress_event_signings: Mutex<HashMap<String, tokio::sync::oneshot::Sender<bool>>>,
@@ -32,24 +34,64 @@ struct KeystacheNip70 {
 }
 
 impl KeystacheNip70 {
-    // TODO: Remove this method and implement a way to load & store keys on disk.
-    fn new_with_generated_keys(app_handle: tauri::AppHandle) -> Self {
+    fn new(app_handle: tauri::AppHandle) -> Self {
         Self {
-            keys: Keys::generate(),
+            database_or: Database::new_in_app_data_dir(app_handle.clone(), None).ok(),
             in_progress_event_signings: Mutex::new(HashMap::new()),
             in_progress_invoice_payments: Mutex::new(HashMap::new()),
             app_handle,
         }
+    }
+
+    /// Wipe all existing keypairs and save a new one.
+    /// TODO: Once we support multiple keypairs, we should remove this.
+    fn set_keypair(&self, keypair: KeyPair) -> Result<(), Nip70ServerError> {
+        let database = match &self.database_or {
+            Some(database) => database,
+            None => return Err(Nip70ServerError::InternalError),
+        };
+
+        // Wipe all existing keypairs.
+        // TODO: Hardcoding the limit here isn't very robust. Should we allow for
+        // setting it to `None` to allow for iterating through all keypairs?
+        for keypair in database.list_keypairs(10_000, 0).map_err(|_| Nip70ServerError::InternalError)? {
+            database.remove_keypair(&keypair.x_only_public_key().0).map_err(|_| {
+                Nip70ServerError::InternalError
+            })?;
+        }
+
+        // Save the new keypair.
+        database
+            .save_keypair(&keypair)
+            .map_err(|_| Nip70ServerError::InternalError)
     }
 }
 
 #[async_trait]
 impl Nip70 for KeystacheNip70 {
     async fn get_public_key(&self) -> Result<XOnlyPublicKey, Nip70ServerError> {
-        Ok(self.keys.public_key())
+        let database = match &self.database_or {
+            Some(database) => database,
+            None => return Err(Nip70ServerError::InternalError),
+        };
+
+        match database.get_first_public_key() {
+            Ok(Some(public_key)) => Ok(public_key),
+            _ => Err(Nip70ServerError::InternalError),
+        }
     }
 
     async fn sign_event(&self, event: UnsignedEvent) -> Result<Event, Nip70ServerError> {
+        let database = match &self.database_or {
+            Some(database) => database,
+            None => return Err(Nip70ServerError::InternalError),
+        };
+
+        let keypair = match database.get_first_keypair() {
+            Ok(Some(keypair)) => keypair,
+            _ => return Err(Nip70ServerError::InternalError),
+        };
+
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.in_progress_event_signings
             .lock()
@@ -64,7 +106,7 @@ impl Nip70 for KeystacheNip70 {
 
         if signing_approved {
             event
-                .sign(&self.keys)
+                .sign(&Keys::new(keypair.secret_key()))
                 .map_err(|_| Nip70ServerError::InternalError)
         } else {
             Err(Nip70ServerError::Rejected)
@@ -158,16 +200,27 @@ async fn get_public_key(
         .map_err(|err| format!("Error: {:?}", err))
 }
 
+#[tauri::command]
+async fn set_nsec(
+    nsec: String,
+    state: tauri::State<'_, Arc<KeystacheNip70>>,
+) -> anyhow::Result<(), String> {
+    let keypair = SecretKey::from_bech32(nsec).map_err(|_| "Error parsing nsec")?.keypair(&Secp256k1::new());
+    state.set_keypair(keypair).map_err(|_| "Error setting keypair")?;
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             respond_to_sign_event_request,
             respond_to_pay_invoice_request,
-            get_public_key
+            get_public_key,
+            set_nsec
         ])
         .setup(|app| {
-            let keystache_nip_70 = Arc::new(KeystacheNip70::new_with_generated_keys(app.handle()));
+            let keystache_nip_70 = Arc::new(KeystacheNip70::new(app.handle()));
             let nip_70_server_or = run_nip70_server(keystache_nip_70.clone()).ok();
             app.manage(keystache_nip_70);
             app.manage(nip_70_server_or);

--- a/src/tauriCommands.ts
+++ b/src/tauriCommands.ts
@@ -69,6 +69,16 @@ export const getPublicKey = async (): Promise<string> => {
   return await invoke("get_public_key");
 };
 
+/**
+ * Set the nSec of the user's Nostr account in the Tauri backend.
+ * @param nsec The new nSec to set.
+ * @returns A promise that resolves when the nSec has been set.
+ * @throws If the nSec is invalid or the Tauri database fails to update.
+ */
+export const setNsec = async (nsec: string): Promise<void> => {
+  return await invoke("set_nsec", { nsec });
+}
+
 type SignEventRequestHandler = (
   event: UnsignedNostrEvent,
 ) => Promise<boolean> | boolean;


### PR DESCRIPTION
Requires #17, do not merge before it.

Adds support for single key using the embedded sqlite database, replacing previous behavior which used a generated key with behavior that uses a DB-backed key. Exposes one additional Tauri command and corresponding TS function, `setNsec()`, for saving the key to the DB.