### PR TITLE
fix: bump nip-55 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3712,9 +3712,9 @@ checksum = "e664971378a3987224f7a0e10059782035e89899ae403718ee07de85bec42afe"
 
 [[package]]
 name = "nip-55"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3aee927c8ce2463921b541826b3293aa9f5b4bd4f0da38caa0a4befc9c818b"
+checksum = "26e34c26278cda951736c61bf27d72b2a6e8397e97cb6b7b08de8435d4f4131e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ iced = { git = "https://github.com/iced-rs/iced", rev = "e50aa03", features = [
 ] }
 libsqlite3-sys = { version = "0.28.0", features = ["bundled-sqlcipher"] }
 lightning-invoice = "0.31.0"
-nip-55 = "0.6.0"
+nip-55 = "0.6.1"
 nostr-sdk = "0.30.0"
 palette = "0.7.6"
 secp256k1 = { version = "0.28.2", features = ["global-context"] }


### PR DESCRIPTION
This resolves an issue in the `nip-55` crate where the server stream locks up after receiving an incoming request encrypted with an unknown key