### PR TITLE
feat: add underlying nostr client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3271,6 +3271,7 @@ dependencies = [
  "libsqlite3-sys",
  "lightning-invoice",
  "nip-55",
+ "nostr-relay-pool",
  "nostr-sdk",
  "palette",
  "secp256k1 0.29.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ iced = { version = "0.13.1", features = [
 libsqlite3-sys = { version = "0.30.1", features = ["bundled-sqlcipher"] }
 lightning-invoice = "0.31.0"
 nip-55 = "0.7.0"
+nostr-relay-pool = "0.35.0"
 nostr-sdk = "0.35.0"
 palette = "0.7.6"
 secp256k1 = { version = "0.29.1", features = ["global-context"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 mod app;
 mod db;
 mod fedimint;
+mod nostr;
 mod routes;
 mod ui_components;
 mod util;
@@ -26,6 +27,7 @@ use iced::window::settings::PlatformSpecific;
 use iced::window::Settings;
 use iced::Size;
 use nip_55::nip_46::Nip46RequestApproval;
+use nostr::{NostrModule, NostrState};
 use nostr_sdk::PublicKey;
 use routes::Loadable;
 
@@ -71,6 +73,8 @@ struct ConnectedState {
         )>,
     >,
     loadable_federation_views: Loadable<BTreeMap<FederationId, FederationView>>,
+    nostr_module: NostrModule,
+    nostr_state: NostrState,
 }
 
 // TODO: Clean up this implementation.

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -1,0 +1,90 @@
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::time::Duration;
+
+use iced::Subscription;
+use nostr_relay_pool::RelayStatus;
+use nostr_sdk::Url;
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct NostrState {
+    pub relay_connections: BTreeMap<Url, RelayStatus>,
+}
+
+#[derive(Debug, Clone)]
+pub enum NostrModuleMessage {
+    ConnectToRelay(String),
+    DisconnectFromRelay(String),
+}
+
+#[derive(Clone)]
+pub struct NostrModule {
+    client: nostr_sdk::Client,
+}
+
+impl NostrModule {
+    pub fn new() -> Self {
+        Self {
+            client: nostr_sdk::Client::default(),
+        }
+    }
+
+    pub fn update(&self, message: NostrModuleMessage) {
+        match message {
+            NostrModuleMessage::ConnectToRelay(url) => {
+                let client = self.client.clone();
+
+                tokio::spawn(async move {
+                    client.add_relay(&url).await.unwrap();
+                    client.connect_relay(url).await.unwrap();
+                });
+            }
+            NostrModuleMessage::DisconnectFromRelay(url) => {
+                let client = self.client.clone();
+
+                tokio::spawn(async move {
+                    client.remove_relay(&url).await.unwrap();
+                });
+            }
+        }
+    }
+
+    pub fn subscription(&self) -> Subscription<NostrState> {
+        const POLL_DURATION: Duration = Duration::from_millis(200);
+
+        let client = self.client.clone();
+
+        Subscription::run_with_id(
+            std::any::TypeId::of::<NostrState>(),
+            // We're wrapping `stream` in a `stream!` macro to make it lazy (meaning `stream` isn't
+            // created unless the outer `stream!` is actually used). This is necessary because the
+            // outer `stream!` is created on every update, but will only be polled if the subscription
+            // ID is new.
+            async_stream::stream! {
+                let mut last_state = NostrState::default();
+                loop {
+                    let new_state = Self::get_state(&client).await;
+                    if new_state != last_state {
+                        yield new_state.clone();
+                        last_state = new_state;
+                    }
+
+                    tokio::time::sleep(POLL_DURATION).await;
+                }
+            },
+        )
+    }
+
+    /// Fetches the current state of the Nostr SDK client.
+    /// Note: This is async because it's grabbing read locks
+    /// on the relay `RwLock`s. No network requests are made.
+    async fn get_state(client: &nostr_sdk::Client) -> NostrState {
+        let mut relay_connections = BTreeMap::new();
+
+        for (url, relay) in client.relays().await {
+            relay_connections.insert(url.clone(), relay.status().await);
+        }
+
+        NostrState { relay_connections }
+    }
+}

--- a/src/ui_components/icon.rs
+++ b/src/ui_components/icon.rs
@@ -6,6 +6,8 @@ use iced::{
     Color, Theme,
 };
 
+const CIRCLE_SVG_BYTES: &[u8] = "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" width=\"24px\" viewBox=\"0 0 100 100\"><circle cx=\"50\" cy=\"50\" r=\"40\" fill=\"black\" /></svg>".as_bytes();
+
 #[derive(Clone, Copy)]
 pub enum SvgIcon {
     Add,
@@ -14,6 +16,7 @@ pub enum SvgIcon {
     ArrowUpward,
     Casino,
     ChevronRight,
+    Circle,
     ContentCopy,
     CurrencyBitcoin,
     Delete,
@@ -50,6 +53,7 @@ impl SvgIcon {
             Self::ArrowUpward => icon_handle!("arrow_upward.svg"),
             Self::Casino => icon_handle!("casino.svg"),
             Self::ChevronRight => icon_handle!("chevron_right.svg"),
+            Self::Circle => Svg::new(Handle::from_memory(CIRCLE_SVG_BYTES)),
             Self::ContentCopy => icon_handle!("content_copy.svg"),
             Self::CurrencyBitcoin => icon_handle!("currency_bitcoin.svg"),
             Self::Delete => icon_handle!("delete.svg"),


### PR DESCRIPTION
Add a `nostr-sdk` client that stays in sync with the UI as relays are added/removed