### PR TITLE
refactor: Wallet owns its update stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,7 @@ dependencies = [
  "secp256k1 0.29.1",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tracing-subscriber",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ nostr-sdk = "0.35.0"
 palette = "0.7.6"
 secp256k1 = { version = "0.29.1", features = ["global-context"] }
 tokio = "1.40.0"
+tokio-stream = "0.1.16"
 tracing-subscriber = "0.3.18"
 
 [dev-dependencies]

--- a/src/app.rs
+++ b/src/app.rs
@@ -185,9 +185,7 @@ impl App {
             // outer `stream!` is created on every update, but will only be polled if the subscription
             // ID is new.
             async_stream::stream! {
-                let mut stream = wallet
-                    .get_update_stream()
-                    .map(Message::UpdateWalletView);
+                let mut stream = wallet.get_update_stream().map(Message::UpdateWalletView);
 
                 while let Some(msg) = stream.next().await {
                     yield msg;


### PR DESCRIPTION
Previously, calling `Wallet::get_update_stream()` spawned a new task on every call. Now, instead, the `Wallet` owns a single task that polls the federation views, and `get_update_stream()` simply creates a new stream that watches for the views that are produced by that single task. This also allowed us to add `Wallet::force_update_view()` which tells the `Wallet`-owned task to immediately produce the next value rather than waiting, and waits for the latest value to be produced. This ensures that `force_update_view()` doesn't complete until all streams returned by `get_update_stream()` have the latest view queued up. We then call `force_update_view()` at the end of all public `Wallet` functions that mutate client state. This ensures that the GUI received the latest view from the `Wallet` view stream before an action function completes.